### PR TITLE
Issue/adapt http get sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,14 @@
 ### Overview
 You can use this template to deploy some IBM Cloud Functions assets for you.  The assets created by this template are described in the manifest.yaml file, which can be found at `template-get-external-resource/runtimes/your_language_choice/manifest.yaml`
 
-The only assets described by this get external resource template are a single action, named weather, which takes as input a location parameter.
+The only assets described by this get external resource template are a single action, named `location`, which takes as input a location parameter.
 
 You can use the wskdeploy tool to deploy this asset yourself using the manifest and available code.
 
-You can invoke this asset via web using `curl https://openwhisk.ng.bluemix.net/api/v1/web/<namespace>/$PACKAGE_NAME/weather?location=Paris`
+You can invoke this asset via web using `curl https://us-south.functions.cloud.ibm.com/api/v1/web/<namespace>/$PACKAGE_NAME/location?location=Paris`
 
 For example:
-`curl https://openwhisk.ng.bluemix.net/api/v1/web/myusername@us.ibm.com_myspace/Get%20Resource/weather?location=Austin`
+`curl https://us-south.functions.cloud.ibm.com/api/v1/web/myusername@us.ibm.com_myspace/get-http-resource/location?location=Austin`
 
 ### Available Languages
 This template is available in node.js and python.

--- a/ansible/files/runtimes.json
+++ b/ansible/files/runtimes.json
@@ -31,38 +31,6 @@
                     "attachmentType": "text/plain"
                 }
             }
-        ],
-        "swift": [
-            {
-                "kind": "swift:4.2",
-                "default": true,
-                "image": {
-                    "name": "action-swift-v4.2",
-                    "prefix": "ibmfunctions",
-                    "tag": "latest"
-                },
-                "deprecated": false,
-                "attached": {
-                    "attachmentName": "codefile",
-                    "attachmentType": "text/plain"
-                }
-            }
-        ],
-        "php": [
-            {
-                "kind": "php:7.3",
-                "default": true,
-                "deprecated": false,
-                "image": {
-                    "name": "action-php-v7.2",
-                    "prefix": "openwhisk",
-                    "tag": "latest"
-                },
-                "attached": {
-                    "attachmentName": "codefile",
-                    "attachmentType": "text/plain"
-                }
-            }
         ]
     },
     "blackboxes": [

--- a/runtimes/nodejs/actions/location.js
+++ b/runtimes/nodejs/actions/location.js
@@ -5,7 +5,7 @@
   * https://{APIHOST}/api/v1/web/{QUALIFIED ACTION NAME}?location=Austin
   *
   * For example:
-  * https://openwhisk.ng.bluemix.net/api/v1/web/myusername@us.ibm.com_myspace/get-resource/weather?location=Austin
+  * https://openwhisk.ng.bluemix.net/api/v1/web/myusername@us.ibm.com_myspace/get-http-resource/location?location=Austin
   *
   * In this case, the params variable will look like:
   *     { "location": "Austin" }

--- a/runtimes/nodejs/manifest.yaml
+++ b/runtimes/nodejs/manifest.yaml
@@ -1,11 +1,11 @@
-# Wskdeploy manifest for Get External Resource - weather
+# Wskdeploy manifest for Get External Resource - location
 
 # Deployment using this manifest file creates the following OpenWhisk components:
-#   Package:  openwhisk-get-external-resource
-#   Action:   openwhisk-get-external-resource/weather.js
+#   Package:  get-http-resource
+#   Action:   get-http-resource/location.js
 #
 # The action can be invoked using:
-# curl https://openwhisk.ng.bluemix.net/api/v1/web/<namespace>/openwhisk-get-external-resource/weather.json?location=<location>
+# curl https://us-south.functions.cloud.ibm.com/api/v1/web/<namespace>/get-http-resource/location.json?location=<location>
 
 project:
   namespace: _
@@ -14,7 +14,7 @@ project:
       version: 1.0
       license: Apache-2.0
       actions:
-        weather:
+        location:
           web-export: true
-          function: actions/weather.js
+          function: actions/location.js
           runtime: nodejs:10

--- a/runtimes/python/actions/location.py
+++ b/runtimes/python/actions/location.py
@@ -7,7 +7,7 @@ import requests
 # https://{APIHOST}/api/v1/web/{QUALIFIED ACTION NAME}?location=Austin
 #
 # For example:
-# https://openwhisk.ng.bluemix.net/api/v1/web/myusername@us.ibm.com_myspace/get-resource/weather?location=Austin
+# https://openwhisk.ng.bluemix.net/api/v1/web/myusername@us.ibm.com_myspace/get-http-resource/location?location=Austin
 #
 # In this case, the params variable will look like:
 # { "location": "Austin" }
@@ -23,7 +23,7 @@ def main(params):
         return {
             'statusCode': r.status_code,
             'headers': { 'Content-Type': 'application/json'},
-            'body': {'message': 'Error procesisng your request'}
+            'body': {'message': 'Error processing your request'}
         }
     else:
         return {

--- a/runtimes/python/manifest.yaml
+++ b/runtimes/python/manifest.yaml
@@ -1,11 +1,11 @@
 # Wskdeploy manifest for Get External Resource - weather
 
 # Deployment using this manifest file creates the following OpenWhisk components:
-#   Package:  openwhisk-get-external-resource
-#   Action:   openwhisk-get-external-resource/weather.js
+#   Package:  get-http-resource
+#   Action:   get-http-resource/location.js
 #
 # The action can be invoked using:
-# curl https://openwhisk.ng.bluemix.net/api/v1/web/<namespace>/openwhisk-get-external-resource/weather.json?location=<location>
+# curl https://us-south.functions.cloud.ibm.com/api/v1/web/<namespace>/get-http-resource/location.json?location=<location>
 
 project:
   namespace: _
@@ -14,7 +14,7 @@ project:
       version: 1.0
       license: Apache-2.0
       actions:
-        weather:
+        location:
           web-export: true
-          function: actions/weather.py
+          function: actions/location.py
           runtime: python:3.7

--- a/tests/src/test/scala/templates/LocationTests.scala
+++ b/tests/src/test/scala/templates/LocationTests.scala
@@ -30,7 +30,7 @@ import spray.json.DefaultJsonProtocol._
 import spray.json._
 
 @RunWith(classOf[JUnitRunner])
-class WeatherTests
+class LocationTests
     extends TestHelpers
     with WskTestHelpers
     with BeforeAndAfterAll {
@@ -38,9 +38,9 @@ class WeatherTests
   implicit val wskprops = WskProps()
   val wsk = new Wsk()
 
-  val deployTestRepo =
-    "https://github.com/ibm-functions/template-get-external-resource"
-  val getExternalResourceAction = "weather"
+  // FIXME - once merged into upstream repo the URL must be set to: "https://github.com/ibm-functions/template-get-external-resource"
+  val deployTestRepo = "https://github.com/reggeenr/template-get-external-resource/tree/issue/adapt-http-get-sample"
+  val getExternalResourceAction = "location"
   val deployAction = "/whisk.system/deployWeb/wskdeploy"
   val deployActionURL =
     s"https://${wskprops.apihost}/api/v1/web${deployAction}.http"
@@ -118,30 +118,30 @@ class WeatherTests
   }
 
   /**
-    * Test the nodejs-8 "Get External Resource" template
+    * Test the nodejs-10 "Get External Resource" template
     */
-  it should "invoke nodejs 10 weather.js and get the result" in withAssetCleaner(
+  it should "invoke nodejs 10 location.js and get the result" in withAssetCleaner(
     wskprops) { (wp, assetHelper) =>
     val timestamp: String = System.currentTimeMillis.toString
-    val name = "weatherNodeJS" + timestamp
-    val file = Some(new File(nodejsfolder, "weather.js").toString());
+    val name = "locationNodeJS" + timestamp
+    val file = Some(new File(nodejsfolder, "location.js").toString());
     assetHelper.withCleaner(wsk.action, name) { (action, _) =>
       action.create(name, file, kind = Some(nodejskind))
     }
 
-    withActivation(wsk.activation,
-                   wsk.action.invoke(name, Map("location" -> "Paris".toJson))) {
+    withActivation(wsk.activation, wsk.action.invoke(name, Map("location" -> "Paris".toJson))) {
       activation =>
         activation.response.success shouldBe true
         activation.response.result.get.toString should include("location")
+        activation.response.result.get.toString should include("Paris")
     }
   }
 
-  it should "invoke nodejs 10 weather.js without input and get weather for Vermont" in withAssetCleaner(
+  it should "invoke nodejs 10 weather.js without input and get location for Austin" in withAssetCleaner(
     wskprops) { (wp, assetHelper) =>
     val timestamp: String = System.currentTimeMillis.toString
-    val name = "weatherNodeJS" + timestamp
-    val file = Some(new File(nodejsfolder, "weather.js").toString());
+    val name = "locationNodeJS" + timestamp
+    val file = Some(new File(nodejsfolder, "location.js").toString());
     assetHelper.withCleaner(wsk.action, name) { (action, _) =>
       action.create(name, file, kind = Some(nodejskind))
     }
@@ -149,17 +149,18 @@ class WeatherTests
     withActivation(wsk.activation, wsk.action.invoke(name)) { activation =>
       activation.response.success shouldBe true
       activation.response.result.get.toString should include("location")
+      activation.response.result.get.toString should include("Austin")
     }
   }
 
   /**
     * Test the python "Get External Resource" template
     */
-  it should "invoke weather.py and get the result" in withAssetCleaner(wskprops) {
+  it should "invoke location.py and get the result" in withAssetCleaner(wskprops) {
     (wp, assetHelper) =>
       val timestamp: String = System.currentTimeMillis.toString
-      val name = "weatherPython" + timestamp
-      val file = Some(new File(pythonfolder, "weather.py").toString());
+      val name = "locationPython" + timestamp
+      val file = Some(new File(pythonfolder, "location.py").toString());
       assetHelper.withCleaner(wsk.action, name) { (action, _) =>
         action.create(name, file, kind = Some(pythonkind))
       }
@@ -170,13 +171,14 @@ class WeatherTests
         activation =>
           activation.response.success shouldBe true
           activation.response.result.get.toString should include("location")
+        activation.response.result.get.toString should include("Paris")
       }
   }
-  it should "invoke weather.py without input and get weather for Vermont" in withAssetCleaner(
+  it should "invoke location.py without input and get location for Austin" in withAssetCleaner(
     wskprops) { (wp, assetHelper) =>
     val timestamp: String = System.currentTimeMillis.toString
-    val name = "weatherPython" + timestamp
-    val file = Some(new File(pythonfolder, "weather.py").toString());
+    val name = "locationPython" + timestamp
+    val file = Some(new File(pythonfolder, "location.py").toString());
     assetHelper.withCleaner(wsk.action, name) { (action, _) =>
       action.create(name, file, kind = Some(pythonkind))
     }
@@ -184,6 +186,7 @@ class WeatherTests
     withActivation(wsk.activation, wsk.action.invoke(name)) { activation =>
       activation.response.success shouldBe true
       activation.response.result.get.toString should include("location")
+      activation.response.result.get.toString should include("Austin")
     }
   }
 

--- a/tests/src/test/scala/templates/LocationTests.scala
+++ b/tests/src/test/scala/templates/LocationTests.scala
@@ -39,7 +39,8 @@ class LocationTests
   val wsk = new Wsk()
 
   // FIXME - once merged into upstream repo the URL must be set to: "https://github.com/ibm-functions/template-get-external-resource"
-  val deployTestRepo = "https://github.com/reggeenr/template-get-external-resource/tree/issue/adapt-http-get-sample"
+  val deployTestRepo =
+    "https://github.com/reggeenr/template-get-external-resource/tree/issue/adapt-http-get-sample"
   val getExternalResourceAction = "location"
   val deployAction = "/whisk.system/deployWeb/wskdeploy"
   val deployActionURL =
@@ -121,7 +122,8 @@ class LocationTests
     * Test the nodejs-10 "Get External Resource" template
     */
   it should "invoke nodejs 10 location.js and get the result" in withAssetCleaner(
-    wskprops) { (wp, assetHelper) =>
+    wskprops
+  ) { (wp, assetHelper) =>
     val timestamp: String = System.currentTimeMillis.toString
     val name = "locationNodeJS" + timestamp
     val file = Some(new File(nodejsfolder, "location.js").toString());
@@ -129,16 +131,19 @@ class LocationTests
       action.create(name, file, kind = Some(nodejskind))
     }
 
-    withActivation(wsk.activation, wsk.action.invoke(name, Map("location" -> "Paris".toJson))) {
-      activation =>
-        activation.response.success shouldBe true
-        activation.response.result.get.toString should include("location")
-        activation.response.result.get.toString should include("Paris")
+    withActivation(
+      wsk.activation,
+      wsk.action.invoke(name, Map("location" -> "Paris".toJson))
+    ) { activation =>
+      activation.response.success shouldBe true
+      activation.response.result.get.toString should include("location")
+      activation.response.result.get.toString should include("Paris")
     }
   }
 
   it should "invoke nodejs 10 weather.js without input and get location for Austin" in withAssetCleaner(
-    wskprops) { (wp, assetHelper) =>
+    wskprops
+  ) { (wp, assetHelper) =>
     val timestamp: String = System.currentTimeMillis.toString
     val name = "locationNodeJS" + timestamp
     val file = Some(new File(nodejsfolder, "location.js").toString());
@@ -156,26 +161,28 @@ class LocationTests
   /**
     * Test the python "Get External Resource" template
     */
-  it should "invoke location.py and get the result" in withAssetCleaner(wskprops) {
-    (wp, assetHelper) =>
-      val timestamp: String = System.currentTimeMillis.toString
-      val name = "locationPython" + timestamp
-      val file = Some(new File(pythonfolder, "location.py").toString());
-      assetHelper.withCleaner(wsk.action, name) { (action, _) =>
-        action.create(name, file, kind = Some(pythonkind))
-      }
+  it should "invoke location.py and get the result" in withAssetCleaner(
+    wskprops
+  ) { (wp, assetHelper) =>
+    val timestamp: String = System.currentTimeMillis.toString
+    val name = "locationPython" + timestamp
+    val file = Some(new File(pythonfolder, "location.py").toString());
+    assetHelper.withCleaner(wsk.action, name) { (action, _) =>
+      action.create(name, file, kind = Some(pythonkind))
+    }
 
-      withActivation(
-        wsk.activation,
-        wsk.action.invoke(name, Map("location" -> "Paris".toJson))) {
-        activation =>
-          activation.response.success shouldBe true
-          activation.response.result.get.toString should include("location")
-        activation.response.result.get.toString should include("Paris")
-      }
+    withActivation(
+      wsk.activation,
+      wsk.action.invoke(name, Map("location" -> "Paris".toJson))
+    ) { activation =>
+      activation.response.success shouldBe true
+      activation.response.result.get.toString should include("location")
+      activation.response.result.get.toString should include("Paris")
+    }
   }
   it should "invoke location.py without input and get location for Austin" in withAssetCleaner(
-    wskprops) { (wp, assetHelper) =>
+    wskprops
+  ) { (wp, assetHelper) =>
     val timestamp: String = System.currentTimeMillis.toString
     val name = "locationPython" + timestamp
     val file = Some(new File(pythonfolder, "location.py").toString());
@@ -190,16 +197,19 @@ class LocationTests
     }
   }
 
-  private def makePostCallWithExpectedResult(params: JsObject,
-                                             expectedResult: String,
-                                             expectedCode: Int) = {
+  private def makePostCallWithExpectedResult(
+      params: JsObject,
+      expectedResult: String,
+      expectedCode: Int
+  ) = {
     val response = RestAssured
       .given()
       .contentType("application/json\r\n")
       .config(
         RestAssured
           .config()
-          .sslConfig(new SSLConfig().relaxedHTTPSValidation()))
+          .sslConfig(new SSLConfig().relaxedHTTPSValidation())
+      )
       .body(params.toString())
       .post(deployActionURL)
     assert(response.statusCode() == expectedCode)
@@ -208,9 +218,11 @@ class LocationTests
       .getFields("activationId") should have length 1
   }
 
-  private def verifyAction(action: RunResult,
-                           name: String,
-                           kindValue: JsString): Unit = {
+  private def verifyAction(
+      action: RunResult,
+      name: String,
+      kindValue: JsString
+  ): Unit = {
     val stdout = action.stdout
     assert(stdout.startsWith(s"ok: got action $name\n"))
     wsk

--- a/tests/src/test/scala/templates/LocationTests.scala
+++ b/tests/src/test/scala/templates/LocationTests.scala
@@ -40,7 +40,7 @@ class LocationTests
 
   // FIXME - once merged into upstream repo the URL must be set to: "https://github.com/ibm-functions/template-get-external-resource"
   val deployTestRepo =
-    "https://github.com/reggeenr/template-get-external-resource/tree/issue/adapt-http-get-sample"
+    "https://github.com/reggeenr/template-get-external-resource"
   val getExternalResourceAction = "location"
   val deployAction = "/whisk.system/deployWeb/wskdeploy"
   val deployActionURL =

--- a/tools/travis/deploy.sh
+++ b/tools/travis/deploy.sh
@@ -15,7 +15,7 @@ IMAGE_PREFIX="openwhisk"
 
 # Deploy OpenWhisk
 cd $OPENWHISK_HOME/ansible
-ANSIBLE_CMD="ansible-playbook -i environments/local -e docker_image_prefix=${IMAGE_PREFIX}"
+ANSIBLE_CMD="ansible-playbook -i environments/local -e docker_image_prefix=${IMAGE_PREFIX} -e docker_image_tag=nightly"
 $ANSIBLE_CMD setup.yml
 $ANSIBLE_CMD prereq.yml
 $ANSIBLE_CMD couchdb.yml

--- a/tools/travis/deploy_wskdeploy.sh
+++ b/tools/travis/deploy_wskdeploy.sh
@@ -20,5 +20,5 @@ mkdir -p ${PREINSTALL_DIR}/ibm-functions/template-get-external-resource
 cp -a ${ROOTDIR}/runtimes ${PREINSTALL_DIR}/ibm-functions/template-get-external-resource/
 
 # Install the deploy package
-cd $HOMEDIR/incubator-openwhisk-package-deploy/packages
+cd $HOMEDIR/openwhisk-package-deploy/packages
 ./installCatalog.sh $WSK_SYSTEM_AUTH_KEY $WHISK_APIHOST $WSK_CLI

--- a/tools/travis/scan.sh
+++ b/tools/travis/scan.sh
@@ -9,7 +9,7 @@ WHISKDIR="$HOMEDIR/openwhisk"
 
 export OPENWHISK_HOME=${OPENWHISK_HOME:=$WHISKDIR}
 
-OPENWHISK_UTILS_HOME=${HOMEDIR}/incubator-openwhisk-utilities
+OPENWHISK_UTILS_HOME=${HOMEDIR}/openwhisk-utilities
 OPENWHISK_SCANCODE_CFG=${ROOTDIR}/tools/build/scanCode.cfg
 
 cd ${ROOTDIR}

--- a/tools/travis/setup.sh
+++ b/tools/travis/setup.sh
@@ -12,13 +12,13 @@ export OPENWHISK_HOME=${OPENWHISK_HOME:=$WHISKDIR}
 cd ${HOMEDIR}
 
 # shallow clone OpenWhisk repo.
-git clone --depth 1 https://github.com/apache/incubator-openwhisk.git ${OPENWHISK_HOME}
+git clone --depth 1 https://github.com/apache/openwhisk.git ${OPENWHISK_HOME}
 
 # shallow clone deploy package repo.
-git clone --depth 1 https://github.com/apache/incubator-openwhisk-package-deploy
+git clone --depth 1 https://github.com/apache/openwhisk-package-deploy
 
 # shallow clone of scancode
-git clone --depth 1 https://github.com/apache/incubator-openwhisk-utilities.git
+git clone --depth 1 https://github.com/apache/openwhisk-utilities.git
 
 # use runtimes.json that defines ibm runtimes
 cp -f ${ROOTDIR}/ansible/files/runtimes.json ${WHISKDIR}/ansible/files/runtimes.json


### PR DESCRIPTION
This PR addresses two things:
- It repairs the broken Travis CI build by changing the referenced OW repositories and pointing to the nightly builds
- Rebranding of the "weather" sample to a "location" sample

This PR does not introduce new code or logic. Additionally, it does not change the template code. As it is right now, users might get confused by using this template because it makes you think it creates an action that somehow interacts with a dynamic weather service (which was true in the past). But in fact the action only requests a httpbin.org server, which returns the given input data.